### PR TITLE
HCK-7343: map partition keys data properly

### DIFF
--- a/reverse_engineering/helpers/tablePropertiesHelper.js
+++ b/reverse_engineering/helpers/tablePropertiesHelper.js
@@ -77,7 +77,7 @@ const mapColumns = ({ columns = [], logger = {} }) => {
 };
 
 const mapTableData = ({ tableData, _, logger }) => {
-	const partitionKeys = tableData.Table.PartitionKeys || [];
+	const partitionKeys = mapColumns({ columns: tableData.Table.PartitionKeys, logger });
 
 	return {
 		name: tableData.Table.Name,
@@ -85,7 +85,7 @@ const mapTableData = ({ tableData, _, logger }) => {
 			description: tableData.Table.Description,
 			externalTable: tableData.Table.TableType === 'EXTERNAL_TABLE',
 			tableProperties: mapTableProperties(tableData.Table.Parameters),
-			compositePartitionKey: partitionKeys.map(item => item.Name),
+			compositePartitionKey: partitionKeys.map(item => item.name),
 			compositeClusteringKey: tableData.Table.StorageDescriptor?.BucketColumns,
 			sortedByKey: mapSortColumns(tableData.Table.StorageDescriptor?.SortColumns),
 			compressed: tableData.Table.StorageDescriptor?.Compressed,
@@ -99,7 +99,7 @@ const mapTableData = ({ tableData, _, logger }) => {
 			serDeParameters: mapSerDeParameters(tableData.Table.StorageDescriptor?.SerdeInfo?.Parameters),
 			classification: getClassification(tableData.Table.Parameters),
 		},
-		partitionKeys: tableData.Table.PartitionKeys || [],
+		partitionKeys,
 		columns: mapColumns({ columns: tableData.Table.StorageDescriptor.Columns, logger }),
 	};
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7343" title="HCK-7343" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7343</a>  Partition Key is not RE-ed properly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* RE result:

![image](https://github.com/user-attachments/assets/ed558133-8929-40fa-bbab-327c56de07bd)
