### PR TITLE
HCK-7580: Improved config to prevent reversed partition keys being set to primary keys by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
                         "hiveQl"
                     ]
                 }
-            ]
+            ],
+            "enableKeysMultipleAbrr": true
         }
     },
     "description": "Hackolade plugin for AWS Glue Data Catalog",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -311,7 +311,8 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Partition key",
 				"propertyKeyword": "compositePartitionKey",
 				"propertyType": "primaryKeySetter",
-				"abbr": "pk,PK"
+				"abbr": "pk,PK",
+				"setPrimaryKey": false
 			},
 			{
 				"propertyName": "Disable No Validate",
@@ -322,7 +323,8 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Clustering key",
 				"propertyKeyword": "compositeClusteringKey",
 				"propertyType": "primaryKeySetter",
-				"abbr": "pk,CK"
+				"abbr": "pk,CK",
+				"setPrimaryKey": false
 			},
 			{
 				"propertyName": "Sorted by",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -311,7 +311,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Partition key",
 				"propertyKeyword": "compositePartitionKey",
 				"propertyType": "primaryKeySetter",
-				"abbr": "pk,PK",
+				"abbr": "PK",
 				"setPrimaryKey": false
 			},
 			{
@@ -323,7 +323,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Clustering key",
 				"propertyKeyword": "compositeClusteringKey",
 				"propertyType": "primaryKeySetter",
-				"abbr": "pk,CK",
+				"abbr": "CK",
 				"setPrimaryKey": false
 			},
 			{

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -143,38 +143,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -249,38 +225,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -348,38 +300,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -415,38 +343,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -483,38 +387,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -550,38 +430,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -636,38 +492,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -746,38 +578,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -814,38 +622,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",
@@ -894,38 +678,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "checkbox"
 			},
 			{
-				"fieldName": "Primary Key",
-				"fieldKeyword": "primaryKey",
+				"propertyName": "Primary Key",
+				"propertyKeyword": "primaryKey",
 				"shouldValidate": false,
-				"fieldType": "checkbox",
-				"changeAction": "changePrimaryKeyOfField",
+				"propertyType": "checkbox",
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk",
-				"disabledOnCondition": [
-					{
-						"key": "refType",
-						"value": "collectionReference"
-					},
-					{
-						"level": "root",
-						"key": "viewOn",
-						"exist": true
-					},
-					{
-						"type": "not",
-						"values": {
-							"level": "parent",
-							"key": "type",
-							"value": "object"
-						}
-					},
-					{
-						"key": "isActivated",
-						"value": false
-					}
-				]
+				"abbr": "pk"
 			},
 			{
 				"propertyName": "Unique",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -150,7 +150,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -232,7 +238,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -307,7 +319,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -350,7 +368,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -394,7 +418,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -437,7 +467,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -499,7 +535,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -585,7 +627,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -629,7 +677,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",
@@ -685,7 +739,13 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"disabledOnTab": "view",
 				"valueType": "boolean",
-				"abbr": "pk"
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
 			},
 			{
 				"propertyName": "Unique",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -142,7 +142,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -215,7 +248,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -281,7 +347,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -315,7 +414,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -350,7 +482,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -384,7 +549,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -437,7 +635,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -514,7 +745,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -549,7 +813,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",
@@ -596,7 +893,40 @@ making sure that you maintain a proper JSON format.
 				"enableForReference": true,
 				"propertyType": "checkbox"
 			},
-			"primaryKey",
+			{
+				"fieldName": "Primary Key",
+				"fieldKeyword": "primaryKey",
+				"shouldValidate": false,
+				"fieldType": "checkbox",
+				"changeAction": "changePrimaryKeyOfField",
+				"enableForReference": true,
+				"disabledOnTab": "view",
+				"valueType": "boolean",
+				"abbr": "pk",
+				"disabledOnCondition": [
+					{
+						"key": "refType",
+						"value": "collectionReference"
+					},
+					{
+						"level": "root",
+						"key": "viewOn",
+						"exist": true
+					},
+					{
+						"type": "not",
+						"values": {
+							"level": "parent",
+							"key": "type",
+							"value": "object"
+						}
+					},
+					{
+						"key": "isActivated",
+						"value": false
+					}
+				]
+			},
 			{
 				"propertyName": "Unique",
 				"propertyKeyword": "unique",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7580" title="HCK-7580" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7580</a>  Change Glue entity level config to prevent partition keys being set by default
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Improved config to prevent reversed partition keys being set to primary keys by default

## Technical details

Improved entityLevelConfig