### PR TITLE
HCK-12443: fix default value for external table property

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -149,20 +149,21 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "External",
 				"propertyKeyword": "externalTable",
 				"propertyType": "checkbox",
+				"defaultValue": true,
+				"disabled": true,
 				"dependency": {
 					"key": "tableFormat",
-					"value": "Standard"
+					"value": "Iceberg"
 				}
 			},
 			{
 				"propertyName": "External",
 				"propertyKeyword": "externalTable",
 				"propertyType": "checkbox",
-				"defaultValue": true,
-				"disabled": true,
+				"defaultValue": false,
 				"dependency": {
 					"key": "tableFormat",
-					"value": "Iceberg"
+					"value": "Standard"
 				}
 			},
 			{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12443" title="HCK-12443" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12443</a>  "External" property should be false by default for standard tables (alpha 1.d)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

When generating a default values ​​config in an application, the last one from the config list gets into the object