### PR TITLE
HCK-12445: fix getting names for sort keys

### DIFF
--- a/forward_engineering/helpers/awsCliScriptHelpers/glueColumnHelper.js
+++ b/forward_engineering/helpers/awsCliScriptHelpers/glueColumnHelper.js
@@ -22,7 +22,7 @@ const getGlueTableClusteringKeyColumns = (properties = {}) => {
 
 const getGlueTableSortingColumns = (sortingItems = [], properties = {}) => {
 	return sortingItems.map(item => {
-		const property = Object.entries(properties).find(([key, value]) => value.id === item.id);
+		const property = Object.entries(properties).find(([key, value]) => value.GUID === item.keyId);
 		const propertyName = property && property[0];
 		return {
 			Column: propertyName,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12445" title="HCK-12445" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12445</a>  [PROD] Sort key in glue script should not be the column mentioned in the PP (and not the first column in the table)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
