### PR TITLE
HCK-14049: alter has DB name already

### DIFF
--- a/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/alterForeignKeyHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/alterForeignKeyHelper.js
@@ -126,28 +126,6 @@ const getAlterForeignKeyScripts = ({ schema, provider, currentSchemaName, ignore
 			.flatMap(getScript);
 	};
 
-	const getRelationshipsScriptsWithUseSchema = (relationships, processRelationships, getScript) => {
-		return processRelationships(relationships, relationship => {
-			const script = getScript(provider)(relationship);
-
-			if (!script) {
-				return [];
-			}
-
-			const schemaName = prepareName(relationship.role.compMod.child.bucket?.name || '');
-
-			if (currentSchemaName === schemaName) {
-				return [script];
-			}
-
-			currentSchemaName = schemaName;
-
-			const useSchemaScript = provider.assignTemplates(templates.useSchema, { schemaName });
-
-			return [useSchemaScript, script];
-		});
-	};
-
 	const deletedRelationships = getItems(schema, 'relationships', 'deleted').filter(
 		relationship => relationship.role?.compMod?.deleted && !ignoreRelationshipIDs.includes(relationship?.role?.id),
 	);
@@ -157,16 +135,8 @@ const getAlterForeignKeyScripts = ({ schema, provider, currentSchemaName, ignore
 	const modifiedRelationships = getItems(schema, 'relationships', 'modified');
 
 	const deleteFkScripts = getDeleteForeignKeyScripts(provider)(deletedRelationships);
-	const addFkScripts = getRelationshipsScriptsWithUseSchema(
-		addedRelationships,
-		generateAddFkScripts,
-		getAddForeignKeyScript,
-	);
-	const modifiedFkScripts = getRelationshipsScriptsWithUseSchema(
-		modifiedRelationships,
-		generateModifyFkScripts,
-		getModifyForeignKeyScript,
-	);
+	const addFkScripts = generateAddFkScripts(addedRelationships, getAddForeignKeyScript(provider));
+	const modifiedFkScripts = generateModifyFkScripts(modifiedRelationships, getModifyForeignKeyScript(provider));
 	return { deleteFkScripts, addFkScripts, modifiedFkScripts };
 };
 

--- a/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/config/templates.js
+++ b/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/config/templates.js
@@ -75,6 +75,4 @@ module.exports = {
 
 	addFkConstraint:
 		'ALTER TABLE ${childTableName} ADD CONSTRAINT ${constraintName} FOREIGN KEY (${childColumns}) REFERENCES ${parentTableName}(${parentColumns})${disableNoValidate};',
-
-	useSchema: 'USE ${schemaName};',
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14049" title="HCK-14049" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14049</a>  [Glue][Script generation options] Unexpected 'USE db_name' before ALTER script section
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...