### PR TITLE
fix: skip empty names

### DIFF
--- a/forward_engineering/hiveHelpers/helpers/generalHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/generalHelper.js
@@ -42,10 +42,15 @@ const checkNameNeedBackticks = name => !/^\w*$/.test(name) || name.startsWith('_
 
 const isReserved = name => RESERVED_WORDS.includes(name.toLowerCase());
 
-const prepareName = (name = '') => {
+const prepareName = name => {
+	if (!name) {
+		return;
+	}
+
 	if ((checkNameNeedBackticks(name) && !isEscaped(name)) || isReserved(name)) {
 		return `\`${name}\``;
 	}
+
 	return name;
 };
 


### PR DESCRIPTION
## Content

* in FE flow to dbt files empty strings are not ignored, so whenever we resolve names - they should remain `undefined`/`null` 