### PR TITLE
HCK-14053: parse table properties in alter

### DIFF
--- a/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/common.js
+++ b/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/common.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 
+const commentPropKey = 'comment';
+
 const getDifferentItems = (newItems = [], oldItems = []) => {
 	const intersection = _.intersectionWith(newItems, oldItems, _.isEqual);
 	return {
@@ -19,18 +21,10 @@ const hydrateTableProperties = ({ new: newItems, old: oldItems }, name, commentS
 
 	const addCommentProp =
 		isCommentChanged && commentState?.new
-			? {
-					tablePropKey: 'comment',
-					tablePropValue: commentState?.new,
-				}
+			? { tablePropKey: commentPropKey, tablePropValue: commentState?.new }
 			: null;
 
-	const dropCommentProp =
-		isCommentChanged && !commentState?.new
-			? {
-					tablePropKey: 'comment',
-				}
-			: null;
+	const dropCommentProp = isCommentChanged && !commentState?.new ? { tablePropKey: commentPropKey } : null;
 
 	const preparePropertiesName = properties =>
 		properties

--- a/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/common.js
+++ b/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/common.js
@@ -9,25 +9,38 @@ const getDifferentItems = (newItems = [], oldItems = []) => {
 };
 
 const hydrateTableProperties = ({ new: newItems, old: oldItems }, name, commentState) => {
-	const hydrateProperties = properties => (properties || '').split(',').map(prop => prop.trim());
 	const prepareProperties = properties =>
 		properties
 			.filter(Boolean)
-			.map(property => property.replace(/(\S+)=([\s\S]+)/, `'$1'='$2'`))
+			.map(property => `'${property.tablePropKey}'='${property.tablePropValue}'`)
 			.join(',\n');
 
 	const isCommentChanged = !_.isEqual(commentState?.new, commentState?.old);
-	const addCommentProp = isCommentChanged && commentState?.new ? `comment=${commentState?.new}` : '';
-	const dropCommentProp = isCommentChanged && !commentState?.new ? `comment` : '';
+
+	const addCommentProp =
+		isCommentChanged && commentState?.new
+			? {
+					tablePropKey: 'comment',
+					tablePropValue: commentState?.new,
+				}
+			: null;
+
+	const dropCommentProp =
+		isCommentChanged && !commentState?.new
+			? {
+					tablePropKey: 'comment',
+				}
+			: null;
 
 	const preparePropertiesName = properties =>
 		properties
 			.filter(Boolean)
-			.map(prop => `'${prop.replace(/(=\S+)/, '')}'`)
+			.map(prop => `'${prop.tablePropKey}'`)
 			.join(', ');
 
-	const newHydrateItems = hydrateProperties(newItems);
-	const oldHydrateItems = hydrateProperties(oldItems);
+	// Ensure newItems and oldItems are arrays
+	const newHydrateItems = Array.isArray(newItems) ? newItems : [];
+	const oldHydrateItems = Array.isArray(oldItems) ? oldItems : [];
 
 	const { add, drop } = getDifferentItems(newHydrateItems, oldHydrateItems);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14053" title="HCK-14053" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14053</a>  [Glue] Fails to generate table script with table properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://hackolade.atlassian.net/browse/HCK-14052

## Technical details

Glue has a table properties object rather than a table properties string, like in the Hive plugin. [It was fixed in regular script](https://github.com/hackolade/glue/blob/e64d8a6a2f82b756ba1bf19ec83bd76f06531ea3/forward_engineering/hiveHelpers/helpers/tableHelper.js#L170).