### PR TITLE
HCK-14051: fix SQL formatting

### DIFF
--- a/forward_engineering/hiveHelpers/generateContainerScript.js
+++ b/forward_engineering/hiveHelpers/generateContainerScript.js
@@ -9,6 +9,7 @@ const { buildScript } = require('./helpers/buildScript');
 const { parseEntities } = require('./helpers/parseEntities');
 const { getWorkloadManagementStatements } = require('./helpers/getWorkloadManagementStatements');
 const { getIsPkOrFkConstraintAvailable, getIsConstraintAvailable } = require('./helpers/constraintHelper');
+const { setMinify } = require('./helpers/generalHelper');
 
 const sortEntitiesByForeignKeyDependencies = ({ entities, relationships }) => {
 	const entitySet = new Set(entities);
@@ -64,11 +65,12 @@ const generateContainerScript = (data, logger, callback, app) => {
 		const areColumnConstraintsAvailable = getIsConstraintAvailable(data);
 		const isPkOrFkConstraintAvailable = getIsPkOrFkConstraintAvailable(data);
 		const needMinify = _.get(data, 'options.additionalOptions', []).find(option => option.id === 'minify')?.value;
+		setMinify(needMinify);
 
 		if (data.isUpdateScript) {
 			const deltaModelSchema = _.first(Object.values(jsonSchema)) || {};
 			const definitions = [modelDefinitions, internalDefinitions, externalDefinitions];
-			const scripts = getAlterScript(deltaModelSchema, definitions, data, app, needMinify);
+			const scripts = getAlterScript(deltaModelSchema, definitions, data, app);
 			callback(null, scripts);
 			return;
 		}
@@ -117,10 +119,7 @@ const generateContainerScript = (data, logger, callback, app) => {
 			]);
 		}, []);
 
-		callback(
-			null,
-			buildScript(needMinify)(...workloadManagementStatements, databaseStatement, ...entities, ...viewsScripts),
-		);
+		callback(null, buildScript(...workloadManagementStatements, databaseStatement, ...entities, ...viewsScripts));
 	} catch (e) {
 		logger.log('error', { message: e.message, stack: e.stack }, 'Hive Forward-Engineering Error');
 

--- a/forward_engineering/hiveHelpers/generateScript.js
+++ b/forward_engineering/hiveHelpers/generateScript.js
@@ -5,6 +5,7 @@ const { getTableStatement } = require('./helpers/tableHelper');
 const { getIndexes } = require('./helpers/indexHelper');
 const { buildScript } = require('./helpers/buildScript');
 const { getIsPkOrFkConstraintAvailable, getIsConstraintAvailable } = require('./helpers/constraintHelper');
+const { setMinify } = require('./helpers/generalHelper');
 
 const generateScript = (data, logger, callback, app) => {
 	try {
@@ -17,17 +18,18 @@ const generateScript = (data, logger, callback, app) => {
 		const areColumnConstraintsAvailable = getIsConstraintAvailable(data);
 		const isPkOrFkConstraintAvailable = getIsPkOrFkConstraintAvailable(data);
 		const needMinify = _.get(data, 'options.additionalOptions', []).find(option => option.id === 'minify')?.value;
+		setMinify(needMinify);
 
 		if (data.isUpdateScript) {
 			const definitions = [modelDefinitions, internalDefinitions, externalDefinitions];
-			const scripts = getAlterScript(jsonSchema, definitions, data, app, needMinify);
+			const scripts = getAlterScript(jsonSchema, definitions, data, app);
 			callback(null, scripts);
 			return;
 		}
 
 		callback(
 			null,
-			buildScript(needMinify)(
+			buildScript(
 				getDatabaseStatement(containerData),
 				getTableStatement(
 					containerData,

--- a/forward_engineering/hiveHelpers/generateViewScript.js
+++ b/forward_engineering/hiveHelpers/generateViewScript.js
@@ -2,11 +2,13 @@ const _ = require('lodash');
 const { getDatabaseStatement } = require('./helpers/databaseHelper');
 const { getViewScript } = require('./helpers/viewHelper');
 const { buildScript } = require('./helpers/buildScript');
+const { setMinify } = require('./helpers/generalHelper');
 
 const generateViewScript = (data, logger, callback, app) => {
 	try {
 		const viewSchema = JSON.parse(data.jsonSchema || '{}');
 		const needMinify = _.get(data, 'options.additionalOptions', []).find(option => option.id === 'minify')?.value;
+		setMinify(needMinify);
 
 		const databaseStatement = getDatabaseStatement(data.containerData);
 
@@ -18,7 +20,7 @@ const generateViewScript = (data, logger, callback, app) => {
 			isKeyspaceActivated: true,
 		});
 
-		callback(null, buildScript(needMinify)(databaseStatement, script));
+		callback(null, buildScript(databaseStatement, script));
 	} catch (error) {
 		logger.log('error', { message: error.message, stack: error.stack }, 'Hive Forward-Engineering Error');
 

--- a/forward_engineering/hiveHelpers/helpers/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/alterScriptFromDeltaHelper.js
@@ -191,7 +191,7 @@ const getInlineRelationships = ({ schema, options }) => {
 	return addedRelationships;
 };
 
-const getAlterScript = (schema, definitions, data, app, needMinify) => {
+const getAlterScript = (schema, definitions, data, app) => {
 	const provider = require('./alterScriptHelpers/provider')(app);
 
 	const inlineDeltaRelationships = getInlineRelationships({ schema, options: data.options });
@@ -236,7 +236,7 @@ const getAlterScript = (schema, definitions, data, app, needMinify) => {
 		.filter(Boolean)
 		.map(script => script.trim());
 	scripts = getCommentedDropScript(scripts, data);
-	return buildScript(needMinify)(...scripts);
+	return buildScript(...scripts);
 };
 
 const getCommentedDropScript = (scripts, data) => {

--- a/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/alterEntityHelper.js
@@ -191,7 +191,7 @@ const getAddCollectionsScripts =
 
 				return statement;
 			})
-			.join('\n');
+			.join(',\n');
 
 		const collectionScript = getTableStatement(
 			...hydratedCollection,

--- a/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/config/templates.js
+++ b/forward_engineering/hiveHelpers/helpers/alterScriptHelpers/config/templates.js
@@ -65,13 +65,13 @@ module.exports = {
 		'ALTER TABLE ${tableName} ADD CONSTRAINT ${constraintName} CHECK (${expression}) ${enable}${noValidate}${rely};',
 
 	addNotNullConstraint:
-		'ALTER TABLE ${tableName} CHANGE ${columnName} ${columnName} ${type} CONSTRAINT ${constraintName} NOT NULL ${enable}${noValidate}${rely};',
+		'ALTER TABLE ${tableName} CHANGE ${columnName} ${columnName} ${type} CONSTRAINT ${constraintName} NOT NULL${enable}${noValidate}${rely};',
 
 	addColumnCheckConstraint:
-		'ALTER TABLE ${tableName} CHANGE ${columnName} ${columnName} ${type} CONSTRAINT ${constraintName} CHECK (${expression}) ${enable}${noValidate}${rely};',
+		'ALTER TABLE ${tableName} CHANGE ${columnName} ${columnName} ${type} CONSTRAINT ${constraintName} CHECK (${expression})${enable}${noValidate}${rely};',
 
 	addDefaultValueConstraint:
-		'ALTER TABLE ${tableName} CHANGE ${columnName} ${columnName} ${type} CONSTRAINT ${constraintName} DEFAULT ${defaultValue} ${enable}${noValidate}${rely};',
+		'ALTER TABLE ${tableName} CHANGE ${columnName} ${columnName} ${type} CONSTRAINT ${constraintName} DEFAULT ${defaultValue}${enable}${noValidate}${rely};',
 
 	addFkConstraint:
 		'ALTER TABLE ${childTableName} ADD CONSTRAINT ${constraintName} FOREIGN KEY (${childColumns}) REFERENCES ${parentTableName}(${parentColumns})${disableNoValidate};',

--- a/forward_engineering/hiveHelpers/helpers/buildScript.js
+++ b/forward_engineering/hiveHelpers/helpers/buildScript.js
@@ -1,25 +1,6 @@
-const sqlFormatter = require('sql-formatter');
-
-const tryFormat = statement => {
-	try {
-		// Fails for complex types https://github.com/sql-formatter-org/sql-formatter/issues/735
-		return sqlFormatter.format(statement, { language: 'spark', tabWidth: 4, linesBetweenQueries: 2 });
-	} catch {
-		return statement;
-	}
+const buildScript = (...statements) => {
+	return statements.filter(Boolean).join('\n\n');
 };
-
-const buildScript =
-	needMinify =>
-	(...statements) => {
-		if (needMinify) {
-			return statements.filter(Boolean).join('\n\n');
-		}
-
-		const script = statements.filter(Boolean).map(tryFormat).join('\n\n');
-
-		return script + '\n';
-	};
 
 module.exports = {
 	buildScript,

--- a/forward_engineering/hiveHelpers/helpers/columnHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/columnHelper.js
@@ -4,6 +4,8 @@ const {
 	prepareName,
 	commentDeactivatedStatements,
 	encodeStringLiteral,
+	shouldMinify,
+	indentString,
 } = require('./generalHelper');
 const { getConstraintOpts } = require('./constraintHelper');
 const { getDefaultConstraintName } = require('./alterScriptHelpers/generalHelper');
@@ -53,15 +55,22 @@ const getStructChildProperties = (getTypeByProperty, definitions) => property =>
 };
 
 const getStruct = (getTypeByProperty, definitions) => property => {
-	const getStructStatement = propertiesString => `struct<${propertiesString}>`;
+	const minify = shouldMinify();
+
+	const getStructStatement = propertiesString =>
+		minify ? `struct<${propertiesString}>` : `struct<\n${propertiesString}\n>`;
 
 	const { activatedProps, deactivatedProps } = getStructChildProperties(getTypeByProperty, definitions)(property);
+
+	const activePropsString = minify ? activatedProps.join(', ') : indentString(activatedProps.join(',\n'));
+	const deactivatedPropsString = minify ? deactivatedProps.join(', ') : indentString(deactivatedProps.join(',\n'));
+
 	if (deactivatedProps.length === 0) {
-		return getStructStatement(activatedProps.join(', '));
+		return getStructStatement(activePropsString);
 	} else if (activatedProps.length === 0) {
-		return getStructStatement(`/* ${activatedProps.join(', ')} */`);
+		return getStructStatement(`/* ${activePropsString} */`);
 	}
-	return getStructStatement(`${activatedProps.join(', ')} /*, ${deactivatedProps.join(', ')}*/`);
+	return getStructStatement(`${activePropsString} /*, ${deactivatedPropsString}*/`);
 };
 
 const getChildBySubtype = (parentType, subtype) => {
@@ -415,7 +424,7 @@ const getColumnConstraintsStatement = ({ collection, column, isAlterScript }) =>
 			postfix,
 		});
 		const columnName = skipName ? '' : ` (${column.name})`;
-		return `CONSTRAINT ${constraintName} ${statement}${columnName} ${noValidate}`;
+		return `CONSTRAINT ${constraintName} ${statement}${columnName} ${noValidate}`.trim();
 	};
 
 	const statements = [];

--- a/forward_engineering/hiveHelpers/helpers/constraintHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/constraintHelper.js
@@ -49,7 +49,7 @@ const getConstraintOpts = ({ noValidateSpecification, enableSpecification, rely 
 
 const getUniqueKeyStatement = (jsonSchema, isParentItemActivated) => {
 	const getStatement = ({ keys, name, constraintOptsStatement }) =>
-		`CONSTRAINT ${prepareName(name)} UNIQUE (${keys})${constraintOptsStatement}`;
+		`CONSTRAINT ${prepareName(name)} UNIQUE (${keys}) ${constraintOptsStatement}`.trim();
 
 	const getColumnsName = columns => columns.map(column => column.name).join(', ');
 	const hydratedUniqueKeys = hydrateUniqueKeys(jsonSchema);

--- a/forward_engineering/hiveHelpers/helpers/constraintHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/constraintHelper.js
@@ -44,7 +44,7 @@ const getConstraintOpts = ({ noValidateSpecification, enableSpecification, rely 
 		return '';
 	}
 
-	return ` ${enableSpecification}${getPartConstraintOpts(noValidateSpecification)}${getPartConstraintOpts(rely)}`;
+	return `${enableSpecification}${getPartConstraintOpts(noValidateSpecification)}${getPartConstraintOpts(rely)}`;
 };
 
 const getUniqueKeyStatement = (jsonSchema, isParentItemActivated) => {

--- a/forward_engineering/hiveHelpers/helpers/foreignKeyHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/foreignKeyHelper.js
@@ -112,7 +112,7 @@ const getForeignKeyConstraint = ({
 }) => {
 	const constraintNameStatement = constraintName ? `CONSTRAINT ${prepareName(constraintName)} ` : '';
 	const statement = `${constraintNameStatement}FOREIGN KEY (${childColumns}) REFERENCES ${parentTableName}(${parentColumns}) ${disableNoValidate ? 'DISABLE NOVALIDATE' : ''}`;
-	return statement;
+	return statement.trim();
 };
 
 const getForeignKeyStatementsByHashItem = hashItem => {

--- a/forward_engineering/hiveHelpers/helpers/foreignKeyHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/foreignKeyHelper.js
@@ -111,7 +111,7 @@ const getForeignKeyConstraint = ({
 	disableNoValidate,
 }) => {
 	const constraintNameStatement = constraintName ? `CONSTRAINT ${prepareName(constraintName)} ` : '';
-	const statement = `,${constraintNameStatement}FOREIGN KEY (${childColumns}) REFERENCES ${parentTableName}(${parentColumns}) ${disableNoValidate ? 'DISABLE NOVALIDATE' : ''}`;
+	const statement = `${constraintNameStatement}FOREIGN KEY (${childColumns}) REFERENCES ${parentTableName}(${parentColumns}) ${disableNoValidate ? 'DISABLE NOVALIDATE' : ''}`;
 	return statement;
 };
 
@@ -138,7 +138,7 @@ const getForeignKeyStatementsByHashItem = hashItem => {
 
 			return commentDeactivatedStatements(statement, isActivated);
 		})
-		.join('\n');
+		.join(',\n');
 };
 
 const getPreparedForeignColumns = (columnsPaths, idToNameHashTable) => {

--- a/forward_engineering/hiveHelpers/helpers/generalHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/generalHelper.js
@@ -135,6 +135,18 @@ const encodeStringLiteral = (str = '') => {
 
 const isDeactivatedStatement = statement => statement.startsWith(BEFORE_DEACTIVATED_STATEMENT);
 
+const minifyState = {
+	enabled: false,
+};
+
+const setMinify = enabled => {
+	minifyState.enabled = enabled;
+};
+
+const shouldMinify = () => {
+	return minifyState.enabled;
+};
+
 module.exports = {
 	buildStatement,
 	getName,
@@ -147,4 +159,6 @@ module.exports = {
 	removeRedundantTrailingCommaFromStatement,
 	encodeStringLiteral,
 	isDeactivatedStatement,
+	setMinify,
+	shouldMinify,
 };

--- a/forward_engineering/hiveHelpers/helpers/tableHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/tableHelper.js
@@ -46,7 +46,7 @@ const getCreateStatement = ({
 			.map(item => item + ' ')
 			.join('');
 	const fullTableName = dbName ? `${dbName}.${tableName}` : tableName;
-	const hasConstraint = primaryKeyStatement || uniqueKeyStatement || checkStatement;
+	const hasConstraint = primaryKeyStatement || uniqueKeyStatement || checkStatement || foreignKeyStatement;
 
 	return buildStatement(
 		`CREATE${tempExtStatement}TABLE ${ifNotExist ? 'IF NOT EXISTS ' : ''}${fullTableName} (`,

--- a/forward_engineering/hiveHelpers/helpers/tableHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/tableHelper.js
@@ -53,11 +53,11 @@ const getCreateStatement = ({
 		isActivated,
 	)(columnStatement, columnStatement + (hasConstraint ? ',' : ''))(
 		primaryKeyStatement,
-		primaryKeyStatement + (uniqueKeyStatement || checkStatement ? ',' : ''),
-	)(uniqueKeyStatement, uniqueKeyStatement + (checkStatement ? ',' : ''))(checkStatement, checkStatement)(
-		foreignKeyStatement,
-		foreignKeyStatement,
-	)(true, ')')(comment, `COMMENT '${encodeStringLiteral(comment)}'`)(
+		primaryKeyStatement + (uniqueKeyStatement || checkStatement || foreignKeyStatement ? ',' : ''),
+	)(uniqueKeyStatement, uniqueKeyStatement + (checkStatement || foreignKeyStatement ? ',' : ''))(
+		checkStatement,
+		checkStatement,
+	)(foreignKeyStatement, foreignKeyStatement)(true, ')')(comment, `COMMENT '${encodeStringLiteral(comment)}'`)(
 		partitionedByKeys,
 		`PARTITIONED BY (${partitionedByKeys})`,
 	)(clusteredKeys, `CLUSTERED BY (${clusteredKeys})`)(sortedKeys && clusteredKeys, `SORTED BY (${sortedKeys})`)(

--- a/forward_engineering/hiveHelpers/helpers/viewHelper.js
+++ b/forward_engineering/hiveHelpers/helpers/viewHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { prepareName, commentDeactivatedStatements, encodeStringLiteral } = require('./generalHelper');
+const { prepareName, commentDeactivatedStatements, encodeStringLiteral, indentString } = require('./generalHelper');
 
 const itemIsDeactivated = item => item.startsWith('-- ');
 
@@ -62,7 +62,7 @@ const getFromStatement = (collectionRefsDefinitionsMap, columns) => {
 		return '';
 	}
 
-	return 'FROM ' + sourceCollections.join(' INNER JOIN ');
+	return 'FROM\n' + indentString(sourceCollections.join('\nINNER JOIN '));
 };
 
 const retrievePropertyFromConfig = (config, tab, propertyName, defaultValue = '') =>
@@ -73,7 +73,7 @@ const retrieveContainerName = containerConfig =>
 
 module.exports = {
 	getViewScript({ schema, viewData, containerData, collectionRefsDefinitionsMap }) {
-		let script = [];
+		const statements = [];
 		const columns = schema.properties || {};
 		const view = _.first(viewData) || {};
 
@@ -86,22 +86,32 @@ module.exports = {
 		const comment = view.description;
 		const fromStatement = getFromStatement(collectionRefsDefinitionsMap, columns);
 		const name = bucketName ? `${bucketName}.${viewName}` : `${viewName}`;
-		const createStatement = `CREATE ${orReplace && !ifNotExists ? 'OR REPLACE ' : ''}${isMaterialized ? 'MATERIALIZED ' : ''}VIEW ${ifNotExist ? 'IF NOT EXISTS ' : ''}${name}`;
 
-		script.push(createStatement);
+		const createStatement = [
+			'CREATE',
+			orReplace && !ifNotExists ? 'OR REPLACE' : '',
+			isMaterialized ? 'MATERIALIZED' : '',
+			'VIEW',
+			ifNotExist ? 'IF NOT EXISTS' : '',
+			name,
+			comment ? `COMMENT '${encodeStringLiteral(comment)}'` : '',
+			'AS',
+		]
+			.filter(Boolean)
+			.join(' ');
+
+		statements.push(createStatement);
 
 		if (schema.selectStatement) {
 			let statement = schema.selectStatement;
-			if (!_.trim(statement).toLowerCase().startsWith('as')) {
-				statement = 'AS ' + statement;
+			if (_.trim(statement).toLowerCase().startsWith('as')) {
+				statement = statement
+					.trim()
+					.replace(/\bAS\b/i, '')
+					.trim();
 			}
 
-			return (
-				createStatement +
-				(comment ? " COMMENT '" + encodeStringLiteral(comment) + "' " : ' ') +
-				statement +
-				';\n\n'
-			);
+			return `${createStatement}\n${statement};`;
 		}
 
 		if (_.isEmpty(columns)) {
@@ -115,14 +125,9 @@ module.exports = {
 			return;
 		}
 
-		if (comment) {
-			script.push(`COMMENT '${encodeStringLiteral(comment)}'`);
-		}
+		const joinedColumns = indentString(joinLastDeactivatedItem(columnsNames).join(',\n'));
+		statements.push('SELECT', joinedColumns, fromStatement);
 
-		const joinedColumns = joinLastDeactivatedItem(columnsNames).join(',\n');
-		script.push(`AS SELECT ${joinedColumns}`);
-		script.push(fromStatement);
-
-		return commentDeactivatedStatements(script.join('\n  ') + ';', view.isActivated);
+		return commentDeactivatedStatements(statements.join('\n') + ';', view.isActivated);
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
 				"@aws-sdk/client-glue": "3.686.0",
 				"@hackolade/fetch": "1.1.0",
 				"antlr4": "4.8.0",
-				"lodash": "4.17.21",
-				"sql-formatter": "15.6.12"
+				"lodash": "4.17.21"
 			},
 			"devDependencies": {
 				"@hackolade/hck-esbuild-plugins-pack": "0.0.1",
@@ -2275,7 +2274,8 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"node_modules/array-buffer-byte-length": {
 			"version": "1.0.1",
@@ -2893,12 +2893,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"license": "MIT"
 		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
@@ -4861,12 +4855,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4891,34 +4879,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"license": "MIT",
-			"dependencies": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"bin": {
-				"nearley-railroad": "bin/nearley-railroad.js",
-				"nearley-test": "bin/nearley-test.js",
-				"nearley-unparse": "bin/nearley-unparse.js",
-				"nearleyc": "bin/nearleyc.js"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://nearley.js.org/#give-to-nearley"
-			}
-		},
-		"node_modules/nearley/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -5310,25 +5270,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"license": "CC0-1.0"
-		},
-		"node_modules/randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"license": "MIT",
-			"dependencies": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5418,15 +5359,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ret": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12"
 			}
 		},
 		"node_modules/reusify": {
@@ -5731,19 +5663,6 @@
 			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
 			"optional": true,
 			"peer": true
-		},
-		"node_modules/sql-formatter": {
-			"version": "15.6.12",
-			"resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.6.12.tgz",
-			"integrity": "sha512-mkpF+RG402P66VMsnQkWewTRzDBWfu9iLbOfxaW/nAKOS/2A9MheQmcU5cmX0D0At9azrorZwpvcBRNNBozACQ==",
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1",
-				"nearley": "^2.20.1"
-			},
-			"bin": {
-				"sql-formatter": "bin/sql-formatter-cli.cjs"
-			}
 		},
 		"node_modules/string-argv": {
 			"version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
         "@aws-sdk/client-glue": "3.686.0",
         "@hackolade/fetch": "1.1.0",
         "antlr4": "4.8.0",
-        "lodash": "4.17.21",
-        "sql-formatter": "15.6.12"
+        "lodash": "4.17.21"
     },
     "lint-staged": {
         "*.{js,json}": "prettier --write"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14051" title="HCK-14051" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14051</a>  Improve struct formatting when Minify=false
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

1. Remove `sql-formatter` because it doesn't support `struct`.
2. Fix custom formatting issues (mainly indents and commas). Make it pretty by default.
3. Keep the Minify button that minifies `struct`. It can be used for other cases.

**Glue note:** the Glue plugin duplicates logic from the Hive plugin. Not everything is used in Glue, but we keep it to make maintenance easier.