### PR TITLE
Removed peer dependency on Electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,6 @@
             "engines": {
                 "hackolade": "6.9.11",
                 "hackoladePlugin": "1.2.0"
-            },
-            "peerDependencies": {
-                "electron": "^41"
             }
         },
         "node_modules/@aws-crypto/crc32": {
@@ -786,63 +783,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@electron/get": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-            "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "env-paths": "^2.2.0",
-                "fs-extra": "^8.1.0",
-                "got": "^11.8.5",
-                "progress": "^2.0.3",
-                "semver": "^6.2.0",
-                "sumchecker": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "global-agent": "^3.0.0"
-            }
-        },
-        "node_modules/@electron/get/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/@electron/get/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "license": "MIT",
-            "peer": true,
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@electron/get/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 4.0.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -1946,19 +1886,6 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@sindresorhus/is": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
         "node_modules/@smithy/config-resolver": {
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.5.1.tgz",
@@ -2430,80 +2357,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-            "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "defer-to-connect": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@types/cacheable-request": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-            "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/http-cache-semantics": "*",
-                "@types/keyv": "^3.1.4",
-                "@types/node": "*",
-                "@types/responselike": "^1.0.0"
-            }
-        },
-        "node_modules/@types/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@types/keyv": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/node": {
-            "version": "24.12.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-            "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "undici-types": "~7.16.0"
-            }
-        },
-        "node_modules/@types/responselike": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-            "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/yauzl": {
-            "version": "2.10.3",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2616,15 +2469,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/boolean": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/bowser": {
             "version": "2.14.1",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -2652,45 +2496,6 @@
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/cacheable-lookup": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-            "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10.6.0"
-            }
-        },
-        "node_modules/cacheable-request": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^4.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^6.0.1",
-                "responselike": "^2.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -2781,19 +2586,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/clone-response": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2818,6 +2610,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -2829,83 +2622,6 @@
                 "supports-color": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decompress-response/node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/del": {
@@ -2931,14 +2647,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/detect-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2950,25 +2658,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/electron": {
-            "version": "41.1.1",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
-            "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@electron/get": "^2.0.0",
-                "@types/node": "^24.9.0",
-                "extract-zip": "^2.0.1"
-            },
-            "bin": {
-                "electron": "cli.js"
-            },
-            "engines": {
-                "node": ">= 12.20.55"
             }
         },
         "node_modules/emoji-regex": {
@@ -2988,26 +2677,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/environment": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -3020,36 +2689,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es6-error": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/esbuild": {
             "version": "0.28.1",
@@ -3154,47 +2793,12 @@
                 "node": ">=12"
             }
         },
-        "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/eventemitter3": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/extract-zip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "get-stream": "^5.1.0",
-                "yauzl": "^2.10.0"
-            },
-            "bin": {
-                "extract-zip": "cli.js"
-            },
-            "engines": {
-                "node": ">= 10.17.0"
-            },
-            "optionalDependencies": {
-                "@types/yauzl": "^2.9.1"
-            }
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -3323,22 +2927,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3374,57 +2962,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/global-agent": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "es6-error": "^4.1.1",
-                "matcher": "^3.0.0",
-                "roarr": "^2.15.3",
-                "semver": "^7.3.2",
-                "serialize-error": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=10.0"
-            }
-        },
-        "node_modules/global-agent/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/globalthis": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/globby": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -3446,50 +2983,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/got": {
-            "version": "11.8.6",
-            "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-            "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@sindresorhus/is": "^4.0.0",
-                "@szmarczak/http-timer": "^4.0.5",
-                "@types/cacheable-request": "^6.0.1",
-                "@types/responselike": "^1.0.0",
-                "cacheable-lookup": "^5.0.3",
-                "cacheable-request": "^7.0.2",
-                "decompress-response": "^6.0.0",
-                "http2-wrapper": "^1.0.0-beta.5.2",
-                "lowercase-keys": "^2.0.0",
-                "p-cancelable": "^2.0.0",
-                "responselike": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/got?sponsor=1"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/has-flag": {
@@ -3500,41 +2998,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-            "license": "BSD-2-Clause",
-            "peer": true
-        },
-        "node_modules/http2-wrapper": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-            "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
             }
         },
         "node_modules/ignore": {
@@ -3678,21 +3141,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/json-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "license": "ISC",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/jsonfile": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -3704,16 +3152,6 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/keyv": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "json-buffer": "3.0.1"
             }
         },
         "node_modules/lint-staged": {
@@ -3863,30 +3301,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/lowercase-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/matcher": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "escape-string-regexp": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3924,16 +3338,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/minimatch": {
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -3954,6 +3358,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/normalize-path": {
@@ -3966,34 +3371,11 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/normalize-url": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -4082,16 +3464,6 @@
                 "@oxlint-tsgolint/win32-x64": "0.23.0"
             }
         },
-        "node_modules/p-cancelable": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-            "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/p-map": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -4143,13 +3515,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4186,27 +3551,6 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4228,19 +3572,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/quick-lru": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -4252,26 +3583,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/resolve-alpn": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/responselike": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "lowercase-keys": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/restore-cursor": {
@@ -4326,25 +3637,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/roarr": {
-            "version": "2.15.4",
-            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "detect-node": "^2.0.4",
-                "globalthis": "^1.0.1",
-                "json-stringify-safe": "^5.0.1",
-                "semver-compare": "^1.0.0",
-                "sprintf-js": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4367,41 +3659,6 @@
             "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
-            }
-        },
-        "node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "license": "ISC",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/semver-compare": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/serialize-error": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "type-fest": "^0.13.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/signal-exit": {
@@ -4468,14 +3725,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/string-argv": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -4531,19 +3780,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/sumchecker": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
-            "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.1.0"
-            },
-            "engines": {
-                "node": ">= 8.0"
-            }
-        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4585,27 +3821,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
-        },
-        "node_modules/type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-            "license": "(MIT OR CC0-1.0)",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/universalify": {
             "version": "2.0.1",
@@ -4652,6 +3867,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/xml-naming": {
@@ -4684,20 +3900,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/eemeli"
-            }
-        },
-        "node_modules/yauzl": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
-            "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "pend": "~1.2.0"
-            },
-            "engines": {
-                "node": ">=12"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -72,9 +72,6 @@
         "antlr4": "4.8.0",
         "lodash": "4.18.1"
     },
-    "peerDependencies": {
-        "electron": "^41"
-    },
     "overrides": {
         "minimatch": "10.2.4",
         "fast-xml-parser": "5.7.3",


### PR DESCRIPTION
## Content

The peer dependency to `electron` was introduced here: https://github.com/hackolade/glue/pull/49/changes#diff-93d094481ecac713bfbd60a244906c48f606c3230427894baa4f7d335f8f6bdaR7.

It is not used anymore since the introduction of `@hackolade/fetch` and causes false-positive security alerts.